### PR TITLE
feat: reject shrinking segment obstacles when generating circle obstacles [PERCEPTION-3288]

### DIFF
--- a/include/obstacle_detector/obstacle_extractor.h
+++ b/include/obstacle_detector/obstacle_extractor.h
@@ -47,6 +47,8 @@
 #include "obstacle_detector/utilities/circle.h"
 #include "obstacle_detector/utilities/point_set.h"
 
+#include <deque>
+
 namespace obstacle_detector
 {
 
@@ -92,7 +94,7 @@ private:
 
   std::list<Point> input_points_;
   std::list<Segment> segments_;
-  std::list<Segment> prev_segments_;
+  std::deque<std::list<Segment>> prev_segments_;
   std::list<Circle> circles_;
 
   // Parameters
@@ -115,6 +117,7 @@ private:
   double p_max_merge_spread_;
   double p_max_circle_radius_;
   double p_radius_enlargement_;
+  double p_prev_seg_buffer_size_;
   double p_shrink_end_dist_;
   double p_shrink_colinear_dist_;
   double p_shrink_between_tol_;

--- a/include/obstacle_detector/obstacle_extractor.h
+++ b/include/obstacle_detector/obstacle_extractor.h
@@ -72,6 +72,7 @@ private:
   bool compareSegments(const Segment& s1, const Segment& s2, Segment& merged_segment);
   bool checkSegmentsProximity(const Segment& s1, const Segment& s2);
   bool checkSegmentsCollinearity(const Segment& segment, const Segment& s1, const Segment& s2);
+  bool checkSegmentShrinking(const Segment& segment, const tf::StampedTransform& transform);
 
   void detectCircles();
   void mergeCircles();
@@ -104,6 +105,7 @@ private:
   bool p_discard_converted_segments_;
   bool p_transform_coordinates_;
   bool p_filter_by_distance_;
+  bool p_check_shrinking_segments_;
   int p_min_group_points_;
 
   double p_distance_proportion_;
@@ -113,6 +115,8 @@ private:
   double p_max_merge_spread_;
   double p_max_circle_radius_;
   double p_radius_enlargement_;
+  double p_shrink_end_dist_;
+  double p_shrink_colinear_dist_;
 
   double p_min_x_limit_;
   double p_max_x_limit_;

--- a/include/obstacle_detector/obstacle_extractor.h
+++ b/include/obstacle_detector/obstacle_extractor.h
@@ -117,6 +117,7 @@ private:
   double p_radius_enlargement_;
   double p_shrink_end_dist_;
   double p_shrink_colinear_dist_;
+  double p_shrink_between_tol_;
 
   double p_min_x_limit_;
   double p_max_x_limit_;

--- a/include/obstacle_detector/obstacle_extractor.h
+++ b/include/obstacle_detector/obstacle_extractor.h
@@ -91,6 +91,7 @@ private:
 
   std::list<Point> input_points_;
   std::list<Segment> segments_;
+  std::list<Segment> prev_segments_;
   std::list<Circle> circles_;
 
   // Parameters

--- a/include/obstacle_detector/utilities/segment.h
+++ b/include/obstacle_detector/utilities/segment.h
@@ -108,7 +108,7 @@ public:
   }
 
   bool isBetweenEndpoints(const Point& p, double tol) const {
-    // Checks if point is between segment endpings (within a tolerance to account for noise)
+    // Checks if point is between segment endpoints (within a tolerance to account for noise)
     // a: vector from first_point to last_point; b: vector from first_point to query point, p;
     // t: scalar of projection of b onto a (0 <= t <= 1 if p is between first_point and last_point)
     Point a = last_point - first_point;

--- a/include/obstacle_detector/utilities/segment.h
+++ b/include/obstacle_detector/utilities/segment.h
@@ -111,7 +111,6 @@ public:
     // Checks if point is between segment endpings (within a tolerance to account for noise)
     Point a = last_point - first_point;
     Point b = p - first_point;
-    Point c = p - last_point;
     double t = a.dot(b) / a.lengthSquared();
     return t > 0.0 - tol && t < 1.0 + tol;
   }

--- a/include/obstacle_detector/utilities/segment.h
+++ b/include/obstacle_detector/utilities/segment.h
@@ -108,7 +108,7 @@ public:
   }
 
   bool isBetweenEndpoints(const Point& p, double tol) const {
-    // Checks if point is between segment endpings within a buffer of 5% to account for noise
+    // Checks if point is between segment endpings (within a tolerance to account for noise)
     Point a = last_point - first_point;
     Point b = p - first_point;
     Point c = p - last_point;

--- a/include/obstacle_detector/utilities/segment.h
+++ b/include/obstacle_detector/utilities/segment.h
@@ -107,6 +107,15 @@ public:
     return (p - projection).length();
   }
 
+  bool isBetweenEndpoints(const Point& p, double tol) const {
+    // Checks if point is between segment endpings within a buffer of 5% to account for noise
+    Point a = last_point - first_point;
+    Point b = p - first_point;
+    Point c = p - last_point;
+    double t = a.dot(b) / a.lengthSquared();
+    return t > 0.0-tol && t < 1.0+tol;
+  }
+
 
   friend std::ostream& operator<<(std::ostream& out, const Segment& s) {
     out << "p1: " << s.first_point << ", p2: " << s.last_point;

--- a/include/obstacle_detector/utilities/segment.h
+++ b/include/obstacle_detector/utilities/segment.h
@@ -109,6 +109,8 @@ public:
 
   bool isBetweenEndpoints(const Point& p, double tol) const {
     // Checks if point is between segment endpings (within a tolerance to account for noise)
+    // a: vector from first_point to last_point; b: vector from first_point to query point, p;
+    // t: scalar of projection of b onto a (0 <= t <= 1 if p is between first_point and last_point)
     Point a = last_point - first_point;
     Point b = p - first_point;
     double t = a.dot(b) / a.lengthSquared();

--- a/include/obstacle_detector/utilities/segment.h
+++ b/include/obstacle_detector/utilities/segment.h
@@ -113,7 +113,7 @@ public:
     Point b = p - first_point;
     Point c = p - last_point;
     double t = a.dot(b) / a.lengthSquared();
-    return t > 0.0-tol && t < 1.0+tol;
+    return t > 0.0 - tol && t < 1.0 + tol;
   }
 
 

--- a/src/obstacle_extractor.cpp
+++ b/src/obstacle_extractor.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Software License Agreement (BSD License)
  *
  * Copyright (c) 2017, Poznan University of Technology
@@ -131,6 +131,7 @@ void ObstacleExtractor::pclCallback(const sensor_msgs::PointCloud::ConstPtr pcl_
 }
 
 void ObstacleExtractor::processPoints() {
+  prev_segments_ = move(segments_);
   segments_.clear();
   circles_.clear();
 

--- a/src/obstacle_extractor.cpp
+++ b/src/obstacle_extractor.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Software License Agreement (BSD License)
  *
  * Copyright (c) 2017, Poznan University of Technology
@@ -74,6 +74,7 @@ bool ObstacleExtractor::updateParams(std_srvs::Empty::Request &req, std_srvs::Em
   nh_local_.param<double>("radius_enlargement", p_radius_enlargement_, 0.25);
   nh_local_.param<double>("shrink_end_dist", p_shrink_end_dist_, 0.05);
   nh_local_.param<double>("shrink_colinear_dist", p_shrink_colinear_dist_, 0.1);
+  nh_local_.param<double>("shrink_between_tol", p_shrink_between_tol_, 0.05);
 
   nh_local_.param<double>("min_x_limit", p_min_x_limit_, -10.0);
   nh_local_.param<double>("max_x_limit", p_max_x_limit_,  10.0);
@@ -318,7 +319,7 @@ bool ObstacleExtractor::checkSegmentShrinking(const Segment& segment, const tf::
         (segment_transformed.last_point - s.last_point).length() < p_shrink_end_dist_)
           to_check_for_colinearity.push_back(&segment_transformed.first_point);
     for (auto p : to_check_for_colinearity) {
-      if (s.distanceTo(*p) < p_shrink_colinear_dist_)
+        if (s.distanceTo(*p) < p_shrink_colinear_dist_ && s.isBetweenEndpoints(*p, p_shrink_between_tol_))
         return true;
     }  
   }

--- a/src/obstacle_extractor.cpp
+++ b/src/obstacle_extractor.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Software License Agreement (BSD License)
  *
  * Copyright (c) 2017, Poznan University of Technology
@@ -61,6 +61,7 @@ bool ObstacleExtractor::updateParams(std_srvs::Empty::Request &req, std_srvs::Em
   nh_local_.param<bool>("circles_from_visibles", p_circles_from_visibles_, true);
   nh_local_.param<bool>("discard_converted_segments", p_discard_converted_segments_, true);
   nh_local_.param<bool>("transform_coordinates", p_transform_coordinates_, true);
+  nh_local_.param<bool>("check_shrinking_segments", p_check_shrinking_segments_, true);
 
   nh_local_.param<int>("min_group_points", p_min_group_points_, 5);
 
@@ -71,6 +72,8 @@ bool ObstacleExtractor::updateParams(std_srvs::Empty::Request &req, std_srvs::Em
   nh_local_.param<double>("max_merge_spread", p_max_merge_spread_, 0.2);
   nh_local_.param<double>("max_circle_radius", p_max_circle_radius_, 0.6);
   nh_local_.param<double>("radius_enlargement", p_radius_enlargement_, 0.25);
+  nh_local_.param<double>("shrink_end_dist", p_shrink_end_dist_, 0.05);
+  nh_local_.param<double>("shrink_colinear_dist", p_shrink_colinear_dist_, 0.1);
 
   nh_local_.param<double>("min_x_limit", p_min_x_limit_, -10.0);
   nh_local_.param<double>("max_x_limit", p_max_x_limit_,  10.0);
@@ -299,6 +302,29 @@ bool ObstacleExtractor::checkSegmentsCollinearity(const Segment& segment, const 
           segment.distanceTo(s2.last_point)  < p_max_merge_spread_);
 }
 
+bool ObstacleExtractor::checkSegmentShrinking(const Segment& segment, const tf::StampedTransform& transform) {
+  Segment segment_transformed = segment;
+  if (p_transform_coordinates_) {
+    segment_transformed.first_point = transformPoint(segment.first_point, transform);
+    segment_transformed.last_point = transformPoint(segment.last_point, transform);
+  }  
+  vector<const Point*> to_check_for_colinearity;
+  for (auto s : prev_segments_) {
+    // If two endpoints of segment and s are close, check the other side of the segment for colinearity
+    if ((segment_transformed.first_point - s.first_point).length() < p_shrink_end_dist_ ||
+        (segment_transformed.first_point - s.last_point).length() < p_shrink_end_dist_)
+          to_check_for_colinearity.push_back(&segment_transformed.last_point);
+    if ((segment_transformed.last_point - s.first_point).length() < p_shrink_end_dist_ ||
+        (segment_transformed.last_point - s.last_point).length() < p_shrink_end_dist_)
+          to_check_for_colinearity.push_back(&segment_transformed.first_point);
+    for (auto p : to_check_for_colinearity) {
+      if (s.distanceTo(*p) < p_shrink_colinear_dist_)
+        return true;
+    }  
+  }
+  return false;
+}
+
 void ObstacleExtractor::detectCircles() {
   for (auto segment = segments_.begin(); segment != segments_.end(); ++segment) {
     if (p_circles_from_visibles_) {
@@ -316,7 +342,21 @@ void ObstacleExtractor::detectCircles() {
     Circle circle(*segment);
     circle.radius += p_radius_enlargement_;
 
-    if (circle.radius < p_max_circle_radius_) {
+    // If checking for shrinking segments, create a transform to get new segments in the correct
+    // frame (prev_segments_ already transformed at time of publishing)
+    tf::StampedTransform transform;
+    if (p_transform_coordinates_ && p_check_shrinking_segments_) {
+      try {
+        tf_listener_.waitForTransform(p_frame_id_, base_frame_id_, stamp_, ros::Duration(0.1));
+        tf_listener_.lookupTransform(p_frame_id_, base_frame_id_, stamp_, transform);
+      }
+      catch (tf::TransformException& ex) {
+        ROS_INFO_STREAM(ex.what());
+        return;
+      }
+    }
+
+    if (circle.radius < p_max_circle_radius_ && !checkSegmentShrinking(*segment, transform)) {
       circles_.push_back(circle);
 
       if (p_discard_converted_segments_) {

--- a/src/obstacle_extractor.cpp
+++ b/src/obstacle_extractor.cpp
@@ -137,8 +137,9 @@ void ObstacleExtractor::pclCallback(const sensor_msgs::PointCloud::ConstPtr pcl_
 
 void ObstacleExtractor::processPoints() {
   prev_segments_.push_front(move(segments_));
-  if (prev_segments_.size() > p_prev_seg_buffer_size_)
+  if (prev_segments_.size() > p_prev_seg_buffer_size_) {
     prev_segments_.pop_back();
+  }
   
   segments_.clear();
   circles_.clear();
@@ -314,15 +315,17 @@ bool ObstacleExtractor::checkSegmentShrinking(const Segment& segment, const tf::
     segment_transformed.last_point = transformPoint(segment.last_point, transform);
   }  
   vector<const Point*> to_check_for_colinearity;
-  for (auto segment_list : prev_segments_) {
-    for (auto s : segment_list) {
+  for (const auto & segment_list : prev_segments_) {
+    for (const auto & s : segment_list) {
       // If two endpoints of segment and s are close, check the other side of the segment for colinearity
       if ((segment_transformed.first_point - s.first_point).length() < p_shrink_end_dist_ ||
-          (segment_transformed.first_point - s.last_point).length() < p_shrink_end_dist_)
+          (segment_transformed.first_point - s.last_point).length() < p_shrink_end_dist_) {
             to_check_for_colinearity.push_back(&segment_transformed.last_point);
+      }
       if ((segment_transformed.last_point - s.first_point).length() < p_shrink_end_dist_ ||
-          (segment_transformed.last_point - s.last_point).length() < p_shrink_end_dist_)
+          (segment_transformed.last_point - s.last_point).length() < p_shrink_end_dist_) {
             to_check_for_colinearity.push_back(&segment_transformed.first_point);
+      }
       for (auto p : to_check_for_colinearity) {
         if (s.distanceTo(*p) < p_shrink_colinear_dist_ && s.isBetweenEndpoints(*p, p_shrink_between_tol_))
           return true;


### PR DESCRIPTION
When driving through an aisle or entering an aisle with low walls, we will first see segment type obstacles. As the wall starts going out of view, these are then (incorrectly) classified as circle type obstacles, which end up shrinking, causing their centers to move toward the robot, causing false hard stops. 

This feature detects when a circle appears close to where a segment previously was in a manner where the endpoints are close on one end and the new segment is colinear with the old segment. If the criteria are met, the conversion to a circle is rejected. As a result, the obstacle is not tracked, and the false positives are mitigated.